### PR TITLE
Fix Collection(CollectionDetail and CoreData) and AdventureView(QuizzEndingView)

### DIFF
--- a/Asteria/Cards & Collections/CardData.swift
+++ b/Asteria/Cards & Collections/CardData.swift
@@ -26,17 +26,11 @@ let collection2 = CollectionType(
     collectionImages: [])
 
 let collection3 = CollectionType(
-    collectionName: """
-                    Phénomènes
-                    observables
-                    """,
+    collectionName: "Phénomènes observables",
     collectionImages: [])
 
 let collection4 = CollectionType(
-    collectionName: """
-                    Astronautes
-                    célèbres
-                    """,
+    collectionName: "Astronautes célèbres",
     collectionImages: [])
 
 

--- a/Asteria/Cards & Collections/CollectionDetail.swift
+++ b/Asteria/Cards & Collections/CollectionDetail.swift
@@ -111,53 +111,53 @@ struct CollectionDetail: View {
                         }
                     }
                     if levelProgression >= 6 {
-                        if isANewCard(card: cardFront6) {
-                            cardWon1.append(SingleCardType(cardFront: cardFront6, cardBack: cardBack6))
-                        }
-                    }
-                    if levelProgression >= 7 {
-                        if isANewCard(card: cardFront7) {
-                            cardWon1.append(SingleCardType(cardFront: cardFront7, cardBack: cardBack7))
-                        }
-                    }
-                    if levelProgression >= 8 {
-                        if isANewCard(card: cardFront8) {
-                            cardWon1.append(SingleCardType(cardFront: cardFront8, cardBack: cardBack8))
-                        }
-                    }
-                    if levelProgression >= 9 {
-                        if isANewCard(card: cardFront9) {
-                            cardWon1.append(SingleCardType(cardFront: cardFront9, cardBack: cardBack9))
-                        }
-                    }
-                    if levelProgression >= 10 {
-                        if isANewCard(card: cardFront10) {
-                            cardWon1.append(SingleCardType(cardFront: cardFront10, cardBack: cardBack10))
-                        }
-                    }
-                    if levelProgression >= 11 {
                         if isANewCard(card: cardFront11) {
                             cardWon1.append(SingleCardType(cardFront: cardFront11, cardBack: cardBack11))
                         }
                     }
-                    if levelProgression >= 12 {
+                    if levelProgression >= 7 {
                         if isANewCard(card: cardFront12) {
                             cardWon1.append(SingleCardType(cardFront: cardFront12, cardBack: cardBack12))
                         }
                     }
-                    if levelProgression >= 13 {
+                    if levelProgression >= 8 {
                         if isANewCard(card: cardFront13) {
                             cardWon1.append(SingleCardType(cardFront: cardFront13, cardBack: cardBack13))
                         }
                     }
-                    if levelProgression >= 14 {
+                    if levelProgression >= 9 {
                         if isANewCard(card: cardFront14) {
                             cardWon1.append(SingleCardType(cardFront: cardFront14, cardBack: cardBack14))
                         }
                     }
-                    if levelProgression >= 15 {
+                    if levelProgression >= 10 {
                         if isANewCard(card: cardFront15) {
                             cardWon1.append(SingleCardType(cardFront: cardFront15, cardBack: cardBack15))
+                        }
+                    }
+                    if levelProgression >= 11 {
+                        if isANewCard(card: cardFront6) {
+                            cardWon1.append(SingleCardType(cardFront: cardFront6, cardBack: cardBack6))
+                        }
+                    }
+                    if levelProgression >= 12 {
+                        if isANewCard(card: cardFront7) {
+                            cardWon1.append(SingleCardType(cardFront: cardFront7, cardBack: cardBack7))
+                        }
+                    }
+                    if levelProgression >= 13 {
+                        if isANewCard(card: cardFront8) {
+                            cardWon1.append(SingleCardType(cardFront: cardFront8, cardBack: cardBack8))
+                        }
+                    }
+                    if levelProgression >= 14 {
+                        if isANewCard(card: cardFront9) {
+                            cardWon1.append(SingleCardType(cardFront: cardFront9, cardBack: cardBack9))
+                        }
+                    }
+                    if levelProgression >= 15 {
+                        if isANewCard(card: cardFront10) {
+                            cardWon1.append(SingleCardType(cardFront: cardFront10, cardBack: cardBack10))
                         }
                     }
                     if levelProgression >= 16 {

--- a/Asteria/Cards & Collections/CollectionView.swift
+++ b/Asteria/Cards & Collections/CollectionView.swift
@@ -26,9 +26,9 @@ struct CollectionView: View {
                 
                     CollectionDetail(collection: collection1)
                     
-                    CollectionDetail(collection: collection2)
-                    
                     CollectionDetail(collection: collection3)
+                    
+                    CollectionDetail(collection: collection2)
                     
                     CollectionDetail(collection: collection4)
                     

--- a/Asteria/Quizz/QuizzEndingView.swift
+++ b/Asteria/Quizz/QuizzEndingView.swift
@@ -83,43 +83,43 @@ struct QuizzEndingView: View {
                         .offset(x: cardOffsetAnim)
                         .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
                 case 6 :
-                    CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Voie lactée", cardFrontImage: "collec2-cardFrontImage-6-voielactee", collectionName: "Galaxie", cardNumber: "1", miniCard: true))
-                        .offset(x: cardOffsetAnim)
-                        .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
-                case 7 :
-                    CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Whirlpool", cardFrontImage: "collec2-cardFrontImage-7-whirlpool", collectionName: "Galaxie", cardNumber: "2", miniCard: true))
-                        .offset(x: cardOffsetAnim)
-                        .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
-                case 8 :
-                    CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Andromède", cardFrontImage: "collec2-cardFrontImage-8-andromede", collectionName: "Galaxie", cardNumber: "3", miniCard: true))
-                        .offset(x: cardOffsetAnim)
-                        .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
-                case 9 :
-                    CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Magellan", cardFrontImage: "collec2-cardFrontImage-9-magellan", collectionName: "Galaxie", cardNumber: "4", miniCard: true))
-                        .offset(x: cardOffsetAnim)
-                        .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
-                case 10 :
-                    CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Horsehead", cardFrontImage: "collec2-cardFrontImage-10-horsehead", collectionName: "Galaxie", cardNumber: "5", miniCard: true))
-                        .offset(x: cardOffsetAnim)
-                        .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
-                case 11 :
                     CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Éclipse", cardFrontImage: "collec3-cardFrontImage-11-eclipse", collectionName: "Phénomènes observables", cardNumber: "1", miniCard: true))
                         .offset(x: cardOffsetAnim)
                         .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
-                case 12 :
+                case 7 :
                     CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Super Lune", cardFrontImage: "collec3-cardFrontImage-12-moon", collectionName: "Phénomènes observables", cardNumber: "2", miniCard: true))
                         .offset(x: cardOffsetAnim)
                         .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
-                case 13 :
+                case 8 :
                     CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Étoiles filantes", cardFrontImage: "collec3-cardFrontImage-13-etoile", collectionName: "Phénomènes observables", cardNumber: "3", miniCard: true))
                         .offset(x: cardOffsetAnim)
                         .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
-                case 14 :
+                case 9 :
                     CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Lumière zodiacale", cardFrontImage: "collec3-cardFrontImage-14-zod-light", collectionName: "Phénomènes observables", cardNumber: "4", miniCard: true))
                         .offset(x: cardOffsetAnim)
                         .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
-                case 15 :
+                case 10 :
                     CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Météorite", cardFrontImage: "collec3-cardFrontImage-15-meteorite", collectionName: "Phénomènes observables", cardNumber: "5", miniCard: true))
+                        .offset(x: cardOffsetAnim)
+                        .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
+                case 11 :
+                    CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Voie lactée", cardFrontImage: "collec2-cardFrontImage-6-voielactee", collectionName: "Galaxie", cardNumber: "1", miniCard: true))
+                        .offset(x: cardOffsetAnim)
+                        .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
+                case 12 :
+                    CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Whirlpool", cardFrontImage: "collec2-cardFrontImage-7-whirlpool", collectionName: "Galaxie", cardNumber: "2", miniCard: true))
+                        .offset(x: cardOffsetAnim)
+                        .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
+                case 13 :
+                    CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Andromède", cardFrontImage: "collec2-cardFrontImage-8-andromede", collectionName: "Galaxie", cardNumber: "3", miniCard: true))
+                        .offset(x: cardOffsetAnim)
+                        .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
+                case 14 :
+                    CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Magellan", cardFrontImage: "collec2-cardFrontImage-9-magellan", collectionName: "Galaxie", cardNumber: "4", miniCard: true))
+                        .offset(x: cardOffsetAnim)
+                        .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
+                case 15 :
+                    CollectionCardFront(collectionCardFront: CardFrontType(cardTitle: "Horsehead", cardFrontImage: "collec2-cardFrontImage-10-horsehead", collectionName: "Galaxie", cardNumber: "5", miniCard: true))
                         .offset(x: cardOffsetAnim)
                         .rotation3DEffect(.degrees(cardRotationAnim), axis: (x: 1, y: 0, z: 1))
                 case 16 :


### PR DESCRIPTION
Fix Collection(CollectionDetail and CoreData) and AdventureView(QuizzEndingView) :

Collection : 

Fix append order (Galaxies/Phénomènes Observables -> Phénomènes Observables/Galaxies)
Fix collectionName in collection 3/4 (Cards doesn't appears in collection due of collectionName conflicts"
Fix order of list in collectionview (collection 2/3 -> 3/2)

Aventure :

Fix order in switch (case) in QuizzEndingView(), we won Galaxies cards when we finished Phénomènes Observables quizz (now it's fix)
